### PR TITLE
feat: wire composer from email detail reply/replyAll/forward buttons

### DIFF
--- a/PrivateMailPackage/Sources/PrivateMailFeature/Domain/Models/ComposerMode.swift
+++ b/PrivateMailPackage/Sources/PrivateMailFeature/Domain/Models/ComposerMode.swift
@@ -109,6 +109,32 @@ public struct ComposerEmailContext: Sendable, Equatable {
         self.isDraft = isDraft
         self.attachmentIds = attachmentIds
     }
+
+    /// Convenience initializer to create a context snapshot from a SwiftData Email model.
+    ///
+    /// Email @Model objects are not Sendable, so this creates a lightweight
+    /// Sendable copy for the composer to use across concurrency boundaries.
+    public init(from email: Email) {
+        self.init(
+            emailId: email.id,
+            accountId: email.accountId,
+            threadId: email.threadId,
+            messageId: email.messageId,
+            inReplyTo: email.inReplyTo,
+            references: email.references,
+            fromAddress: email.fromAddress,
+            fromName: email.fromName,
+            toAddresses: email.toAddresses,
+            ccAddresses: email.ccAddresses,
+            bccAddresses: email.bccAddresses,
+            subject: email.subject,
+            bodyPlain: email.bodyPlain,
+            bodyHTML: email.bodyHTML,
+            dateSent: email.dateSent,
+            isDraft: email.isDraft,
+            attachmentIds: email.attachments.map(\.id)
+        )
+    }
 }
 
 /// Pre-filled composer fields based on composition mode.

--- a/PrivateMailPackage/Sources/PrivateMailFeature/Presentation/ThreadList/ThreadListView.swift
+++ b/PrivateMailPackage/Sources/PrivateMailFeature/Presentation/ThreadList/ThreadListView.swift
@@ -301,7 +301,10 @@ struct ThreadListView: View {
                 manageThreadActions: manageThreadActions,
                 downloadAttachment: downloadAttachment,
                 summarizeThread: nil,
-                smartReply: nil
+                smartReply: nil,
+                composeEmail: composeEmail,
+                queryContacts: queryContacts,
+                accounts: accounts
             )
         }
         .accessibilityLabel("Email threads")


### PR DESCRIPTION
- Add ComposerEmailContext.init(from: Email) convenience initializer for converting SwiftData models to Sendable composer snapshots
- Wire reply, reply-all, forward toolbar buttons in EmailDetailView to open the composer sheet with prefilled data
- Wire smart reply suggestion tap to open reply composer
- Pass composeEmail, queryContacts, accounts deps through to EmailDetailView from ThreadListView

All 515 tests passing.