### PR TITLE
feat: Phase 6 error toasts, swipe actions & graceful DB error handling

### DIFF
--- a/VaultMailPackage/Sources/VaultMailFeature/Presentation/Shared/DatabaseErrorView.swift
+++ b/VaultMailPackage/Sources/VaultMailFeature/Presentation/Shared/DatabaseErrorView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+/// Full-screen error view displayed when the SwiftData ModelContainer
+/// fails to initialise at app launch.
+///
+/// Provides the user with a clear, non-technical explanation and a
+/// contact-support mailto link so they can report the problem.
+///
+/// This view replaces the previous `fatalError` crash path, ensuring the
+/// app never terminates without giving the user actionable feedback.
+public struct DatabaseErrorView: View {
+    let message: String
+
+    public init(message: String) {
+        self.message = message
+    }
+
+    public var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.red)
+                .accessibilityHidden(true)
+
+            Text("Unable to Open Database")
+                .font(.title2.bold())
+                .multilineTextAlignment(.center)
+
+            Text("VaultMail was unable to set up its local database. This may be caused by low storage space or a corrupted data file.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            // Technical detail (collapsible)
+            DisclosureGroup("Technical Details") {
+                Text(message)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 4)
+            }
+            .padding(.horizontal, 32)
+            .tint(.secondary)
+
+            if let url = URL(string: "mailto:support@appripe.com?subject=VaultMail%20Database%20Error&body=\(message.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") {
+                Link(destination: url) {
+                    Label("Contact Support", systemImage: "envelope")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.horizontal, 32)
+            }
+
+            Spacer()
+        }
+        .padding()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Database error. VaultMail was unable to open its local database. \(message)")
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Database Error") {
+    DatabaseErrorView(message: "ModelContainer init failed: NSError Domain=NSCocoaErrorDomain Code=134060")
+}

--- a/VaultMailPackage/Sources/VaultMailFeature/Presentation/ThreadList/ErrorToastView.swift
+++ b/VaultMailPackage/Sources/VaultMailFeature/Presentation/ThreadList/ErrorToastView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// A floating bottom toast overlay for error feedback on thread actions.
+///
+/// Displays a red-tinted error message with an exclamation icon.
+/// Auto-dismisses after 4 seconds. Follows the same visual pattern as
+/// `UndoToastView` for consistency.
+///
+/// Spec ref: Thread List spec FR-TL-03 (Phase 6 error toast)
+struct ErrorToastView: View {
+    let message: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+                .accessibilityHidden(true)
+
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+
+            Spacer()
+
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityLabel("Dismiss error")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(.red.opacity(0.3), lineWidth: 1)
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 16)
+        .frame(maxWidth: .infinity)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .task {
+            try? await Task.sleep(for: .seconds(4))
+            onDismiss()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Error: \(message). Tap to dismiss.")
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Error Toast — Archive Failed") {
+    ZStack(alignment: .bottom) {
+        Color.gray.opacity(0.15)
+            .ignoresSafeArea()
+
+        ErrorToastView(
+            message: "Failed to archive thread",
+            onDismiss: {}
+        )
+    }
+}
+
+#Preview("Error Toast — Delete Failed") {
+    ZStack(alignment: .bottom) {
+        Color.gray.opacity(0.15)
+            .ignoresSafeArea()
+
+        ErrorToastView(
+            message: "Failed to delete threads",
+            onDismiss: {}
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `fatalError` crash with `DatabaseErrorView` when ModelContainer init fails (P1 audit item)
- Extract `AppDependencies` struct for cleaner dependency management in `VaultMailApp`
- Add swipe actions: read/unread toggle and star/unstar on thread rows
- Add `ErrorToastView` component and undo toast for archive/delete feedback
- Replace all 6 TODO error-toast placeholders with real error messages (P2 audit item)

## Test plan
- [ ] Verify app launches normally (happy path unchanged)
- [ ] Simulate ModelContainer failure to confirm `DatabaseErrorView` appears
- [ ] Test swipe left on thread row: archive + read/unread toggle
- [ ] Test swipe right on thread row: delete + star/unstar
- [ ] Verify error toasts auto-dismiss after 4 seconds
- [ ] Verify undo toast for archive/delete restores thread
- [ ] Test multi-select archive/delete/mark-read/star shows error toast on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)